### PR TITLE
Highlight players when they have the flag

### DIFF
--- a/CoronaCraft/src/com/gmail/mattdiamond98/coronacraft/CoronaCraft.java
+++ b/CoronaCraft/src/com/gmail/mattdiamond98/coronacraft/CoronaCraft.java
@@ -19,6 +19,8 @@ import com.gmail.mattdiamond98.coronacraft.event.CoolDownEndEvent;
 import com.gmail.mattdiamond98.coronacraft.event.CoolDownTickEvent;
 import com.gmail.mattdiamond98.coronacraft.event.PlayerEventListener;
 import com.gmail.mattdiamond98.coronacraft.util.AbilityKey;
+import com.gmail.mattdiamond98.coronacraft.util.PlayerTimer;
+import com.gmail.mattdiamond98.coronacraft.util.PlayerTimerKey;
 import org.bukkit.Bukkit;
 import org.bukkit.Material;
 import org.bukkit.entity.Player;
@@ -39,6 +41,8 @@ public class CoronaCraft extends JavaPlugin {
     private static final Map<AbilityKey, Integer> PLAYER_ABILITIES = new HashMap<>();
     // Player metadata for tracking which abilities are on cooldown
     private static final Map<AbilityKey, Integer> PLAYER_COOL_DOWNS = new HashMap<>();
+    // Player metadata for tracking timers associated with players
+    private static final Map<PlayerTimerKey, Integer> PLAYER_TASK_MAP = new HashMap<>();
 
     @Override
     public void onEnable(){
@@ -118,6 +122,32 @@ public class CoronaCraft extends JavaPlugin {
         PLAYER_COOL_DOWNS.put(new AbilityKey(p, item), coolDown);
     }
 
+    public static final void addPlayerTimer(PlayerTimerKey ptk, int taskId) {
+        PLAYER_TASK_MAP.put(ptk, taskId);
+    }
+
+    public static final void addPlayerTimer(Player p, PlayerTimer playerTimer, int taskId) {
+        addPlayerTimer(new PlayerTimerKey(player, playerTimer), taskId);
+    }
+
+    public static final void removePlayerTimer(PlayerTimerKey ptk) {
+        if (PLAYER_TASK_MAP.containsKey(ptk))
+            PLAYER_TASK_MAP.remove(ptk);
+    }
+
+    public static final void removePlayerTimer(Player p, PlayerTimer playerTimer) {
+        removePlayerTimer(new PlayerTimerKey(p, playerTimer));
+    }
+
+    public static final int getTaskId(PlayerTimerKey ptk) {
+        return PLAYER_TASK_MAP.get(ptk);
+    }
+
+    public static final int getTaskId(Player p, PlayerTimer playerTimer) {
+        return getTaskId(new PlayerTimerKey(p, playerTimer));
+    }
+
     @Override
     public void onDisable(){}
+
 }

--- a/CoronaCraft/src/com/gmail/mattdiamond98/coronacraft/event/PlayerEventListener.java
+++ b/CoronaCraft/src/com/gmail/mattdiamond98/coronacraft/event/PlayerEventListener.java
@@ -4,8 +4,11 @@ import com.gmail.mattdiamond98.coronacraft.Ability;
 import com.gmail.mattdiamond98.coronacraft.AbilityStyle;
 import com.gmail.mattdiamond98.coronacraft.CoronaCraft;
 import com.gmail.mattdiamond98.coronacraft.util.AbilityUtil;
+import com.gmail.mattdiamond98.coronacraft.util.PlayerTimerKey;
+import com.gmail.mattdiamond98.coronacraft.util.PlayerTimerKey.PlayerTimer;
 import com.tommytony.war.Team;
 import com.tommytony.war.Warzone;
+import com.tommytony.war.event.WarPlayerThiefEvent;
 import org.bukkit.Bukkit;
 import org.bukkit.GameMode;
 import org.bukkit.Material;
@@ -26,10 +29,10 @@ import org.bukkit.event.player.PlayerPickupArrowEvent;
 import org.bukkit.event.player.PlayerToggleSneakEvent;
 import org.bukkit.inventory.ItemStack;
 
+import java.sql.Timestamp;
 import java.util.*;
 
 public class PlayerEventListener implements Listener {
-
     public Set<Material> lockedItems() {
         if (CoronaCraft.getAbilities() == null) return new HashSet<>();
         Set<Material> base = new HashSet<>(CoronaCraft.getAbilities().keySet());
@@ -132,4 +135,76 @@ public class PlayerEventListener implements Listener {
             ((AbstractArrow) e.getEntity()).setPickupStatus(AbstractArrow.PickupStatus.DISALLOWED);
     }
 
+    @EventHandler
+    public void onFlagStolen(WarPlayerThiefEvent e) {
+        if (e.getStolenObject() == StolenObject.FLAG) {
+            int t_long = 10;
+            int t_short = 5;
+
+            Player p = e.getThief();
+            
+            // schedule anti-hide task
+            int taskIdLong = Bukkit.getServer().getScheduler().scheduleSyncDelayedTask(this, () -> {
+                if (Warzone.isFlagThief(p)) {
+                    p.setGlowing(true);
+                }
+            }, t_long);
+            
+            if (taskIdLong != -1)
+                CaronaCraft.addPlayerTimer(p, PlayerTimer.FLAG_IND, taskIdLong);
+
+            Team p_team = Team.getTeamByPlayerName(p);
+            Team o_team = WarZone.getVictimTeamForFlagThief(p);
+
+            if (Warzone.isTeamFlagStolen(p_team)) {
+                for (Player o_p : o_team.getPlayers()) {
+                    if (Warzone.isFlagThief(o_p)) {
+                        // schedule omni-team anti-hide task
+                        int taskIdShort = Bukkit.getServer().getScheduler().scheduleSyncDelayedTask(this, () -> {
+                            if (Warzone.isFlagThief(p) && Warzone.isFlagThief(o_p)) {
+                                p.setGlowing(true);
+                                o_p.setGlowing(true);
+                            }
+                        }, t_short);
+
+                        if (taskIdShort != -1) {
+                            CaronaCraft.addPlayerTimer(p, PlayerTimer.FLAG_BOTH, taskIdShort);
+                            CaronaCraft.addPlayerTimer(o_p, PlayerTimer.FLAG_BOTH, taskIdShort);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    @EventHandler
+    public void onPlayerDeath(WarPlayerDeathEvent e) {
+        // clear single life player timers
+        Player p = e.getVictim();
+        Player k = e.getKiller();
+
+        Team o_team = Team.getTeamByPlayerName(k);
+
+        if (Warzone.isFlagThief(p)) {
+            // cancel long capture timer
+            PlayerTimerKey longPTK = new PlayerTimerKey(p, PlayerTimer.FLAG_IND);
+            int longTaskId = CaronaCraft.getTaskId(longPTK);
+            
+            Bukkit.getServer().getScheduler().cancelTask(longTaskId);
+            CaronaCraft.removePlayerTimer(longPTK);
+
+            // cancel short capture timer
+            PlayerTimerKey shortPTKMe = new PlayerTimerKey(p, PlayerTimer.FLAG_BOTH);
+            int shortTaskId = CaronaCraft.getTaskId(shortPTKMe);
+
+            Bukkit.getServer().getScheduler().cancelTask(shortTaskId);
+            CaronaCraft.removePlayerTimer(shortPTKMe);
+
+            for (Player o_p : o_team.getPlayers()) {
+                if (Warzone.isFlagThief(o_p)) {
+                    CaronaCraft.removePlayerTimer(o_p, PlayerTimer.FLAG_BOTH);
+                }
+            }
+        }
+    }
 }

--- a/CoronaCraft/src/com/gmail/mattdiamond98/coronacraft/util/PlayerTimerKey.java
+++ b/CoronaCraft/src/com/gmail/mattdiamond98/coronacraft/util/PlayerTimerKey.java
@@ -1,0 +1,60 @@
+package com.gmail.mattdiamond98.coronacraft.util;
+
+import com.gmail.mattdiamond98.coronacraft.CoronaCraft;
+import org.bukkit.entity.Player;
+
+import java.util.UUID;
+
+/***
+ * A tuple key object for storing players and 
+ * timer types in data structures.
+ */
+public final class PlayerTimerKey {
+    private UUID playerId;
+    private PlayerTimer playerTimer;
+
+    public PlayerTimerKey(UUID playerId, PlayerTimer playerTimer) {
+        this.playerId = playerId;
+        this.playerTimer = playerTimer;
+    }
+
+    public PlayerTimerKey(Player player, PlayerTimer playerTimer) {
+        this(player.getUniqueId(), playerTimer);
+    }
+
+    public PlayerTimerKey(String playerName, PlayerTimer playerTimer) {
+        this(CoronaCraft.instance.getServer().getPlayer(playerName).getUniqueId(), playerTimer);
+    }
+    
+    public Player getPlayer() {
+        return CoronaCraft.instance.getServer().getPlayer(playerID);
+    }
+
+    public UUID getPlayerID() {
+        return playerID;
+    }
+
+    public PlayerTimer getPlayerTimer() {
+        return playerTimer;
+    }
+
+    @Override
+    public booleoan equals(Object o) {
+        if (o == null) return false;
+        if (!(o instanceof PlayerTimerKey)) return false;
+
+        PlayerTimerKey other = (PlayerTimerKey) o;
+        
+        return playerId.equals(other.playerId) && playerTimer.equals(o.playerTimer);
+    }
+
+    @Override
+    public int hashCode() {
+        return playerId.hashCode() * playerTimer.hashCode();
+    }
+
+    public enum PlayerTimer {
+        FLAG_IND,
+        FLAG_BOTH,
+    }
+}


### PR DESCRIPTION
Coronacraft: Added PLAYER_TASK_MAP, which keeps track of scheduled timers attached to players by mapping players and the task type to the scheduled tasks id. Also added helped methods for interacting with it.

PlayerEventListener: Added 2 new event listeners. One triggers when the flag is stolen and schedules individual and both team flag member highlight tasks. The other triggers on any players death and clears the flag stolen tasks if necessary.

PlayerTimerKey: Added a new data type to keep track and players and there tasks mapped to the scheduled tasks id.
